### PR TITLE
Fixed company_name and detail_code fields based on real world results

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,7 +28,7 @@ info:
     ## Getting Started
 
     If you're new to REST APIs then be sure to read our [introduction to
-    REST](https://www.shipengine.com/docs/rest/) to understand the basics. 
+    REST](https://www.shipengine.com/docs/rest/) to understand the basics.
     Learn how to [authenticate yourself to
     ShipEngine](https://www.shipengine.com/docs/auth/), and then use our
     [sandbox environment](https://www.shipengine.com/docs/sandbox/) to kick the
@@ -167,7 +167,7 @@ paths:
                 text_only:
                   description: >
                     This response shows that the address-recognition API was
-                    able to recognize all the address entities in the text. 
+                    able to recognize all the address entities in the text.
                     Notice that the `country_code` is not populated and the
                     `address_residential_indicator` is "unknown", since neither
                     of these fields was included in the text.
@@ -246,7 +246,7 @@ paths:
                 some_known_fields:
                   description: >
                     This response is shows that the address-recognition API was
-                    able to recognize all the address entities in the text. 
+                    able to recognize all the address entities in the text.
                     Notice that the `country_code` and
                     `address_residential_indicator` fields are populated with
                     the values that were provided in the request.
@@ -2593,7 +2593,7 @@ paths:
                 text_only:
                   description: >
                     This response shows that the shipment-recognition API was
-                    able to recognize all the shipping entities in the text. 
+                    able to recognize all the shipping entities in the text.
                     Notice that the `ship_from` field is not populated, since it
                     wasn't included in the request or in the parsed text.
                   value:
@@ -2786,7 +2786,7 @@ paths:
                 some_known_fields:
                   description: >
                     This response is shows that the shipment-recognition API was
-                    able to recognize all the shipping entities in the text. 
+                    able to recognize all the shipping entities in the text.
                     Notice that the `ship_from` and `service_code` fields are
                     populated with the values that were provided in the request.
                   value:
@@ -3694,6 +3694,7 @@ components:
         company_name:
           type: string
           minLength: 1
+          nullable: true
           example: The Home Depot
           description: >
             If this is a business address, then the company name should be
@@ -4125,6 +4126,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/address_validation_message_type'
         detail_code:
+          nullable: true
           allOf:
             - $ref: '#/components/schemas/address_validation_detail_code'
     address_validation_code:
@@ -4438,7 +4440,7 @@ components:
         - letter
       description: >
         The available layouts (sizes) in which shipping labels can be
-        downloaded.  The label format determines which sizes are supported. 
+        downloaded.  The label format determines which sizes are supported.
         `4x6` is supported for all label formats, whereas `letter` (8.5" x 11")
         is only supported for `pdf` format.
     label_format:
@@ -4449,7 +4451,7 @@ components:
         - png
         - zpl
       description: >
-        The possible file formats in which shipping labels can be downloaded. 
+        The possible file formats in which shipping labels can be downloaded.
         We recommend `pdf` format because it is supported by all carriers,
         whereas some carriers do not support the `png` or `zpl` formats.
 
@@ -4906,7 +4908,7 @@ components:
       description: >
         A [package
         type](https://www.shipengine.com/docs/reference/list-carrier-packages/),
-        such as `thick_envelope`, `small_flat_rate_box`, `large_package`, etc. 
+        such as `thick_envelope`, `small_flat_rate_box`, `large_package`, etc.
         Use the code `package` for custom or unknown package types.
     dimensions:
       title: dimensions
@@ -6613,7 +6615,7 @@ components:
                   - $ref: '#/components/schemas/date'
                 readOnly: true
                 description: >
-                  The date that the package was (or will be) shippped. 
+                  The date that the package was (or will be) shippped.
                   ShipEngine will take the day of week into consideration. For
                   example, if the carrier does not operate on Sundays, then a
                   package that would have shipped on Sunday will ship on Monday
@@ -6825,7 +6827,7 @@ components:
                   The label's package(s).
 
 
-                  > **Note:** Some carriers only allow one package per label. 
+                  > **Note:** Some carriers only allow one package per label.
                   If you attempt to create a multi-package label for a carrier
                   that doesn't allow it, an error will be returned.
                 items:
@@ -7252,7 +7254,7 @@ components:
           description: >
             The shipment's origin address. If you frequently ship from the same
             location, consider [creating a
-            warehouse](https://www.shipengine.com/docs/reference/create-warehouse/). 
+            warehouse](https://www.shipengine.com/docs/reference/create-warehouse/).
             Then you can simply specify the `warehouse_id` rather than the
             complete address each time.
         warehouse_id:
@@ -7543,7 +7545,7 @@ components:
           default: null
           description: >
             This field is used to [bill shipping costs to a third
-            party](https://www.shipengine.com/docs/shipping/bill-to-third-party/). 
+            party](https://www.shipengine.com/docs/shipping/bill-to-third-party/).
             This field must be used in conjunction with the
             `bill_to_country_code`, `bill_to_party`, and `bill_to_postal_code`
             fields.
@@ -7612,7 +7614,7 @@ components:
           default: null
           description: >
             Whether to use [UPS Ground Freight
-            pricing](https://www.shipengine.com/docs/shipping/ups-ground-freight/). 
+            pricing](https://www.shipengine.com/docs/shipping/ups-ground-freight/).
             If enabled, then a `freight_class` must also be specified.
         freight_class:
           type: string
@@ -7726,7 +7728,7 @@ components:
       title: tag
       type: object
       description: >
-        Tags are arbitrary strings that you can use to categorize shipments. 
+        Tags are arbitrary strings that you can use to categorize shipments.
         For example, you may want to use tags to distinguish between domestic
         and international shipments, or between insured and uninsured
         shipments.  Or maybe you want to create a tag for each of your customers
@@ -8280,7 +8282,7 @@ components:
       type: object
       description: >
         Used for combining packages into one scannable form that a carrier can
-        use when picking up a large 
+        use when picking up a large
 
         number of shipments
       additionalProperties: false
@@ -9446,7 +9448,7 @@ components:
       minLength: 1
       example: Fragile
       description: >
-        Tags are arbitrary strings that you can use to categorize shipments. 
+        Tags are arbitrary strings that you can use to categorize shipments.
         For example, you may want to use tags to distinguish between domestic
         and international shipments, or between insured and uninsured
         shipments.  Or maybe you want to create a tag for each of your customers


### PR DESCRIPTION
Fixed specification to match real world practice. The company_name field can come back missing in address validation requests, so this field needs to be set as nullable. The detail_code for the address validation response message is also missing when you warnings about the suite/apt number not being present:

 "messages": [
      {
        "code": "a1002",
        "message": "Suite / Apt Number Not Found or Invalid",
        "type": "warning"
      }
    ]

So this field needs to be nullable also.