### PR TITLE
Support Empty Values for Tracking Event Postal Code

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8177,7 +8177,7 @@ components:
           type: string
           readOnly: true
           example: 78756
-          minLength: 5
+          minLength: 0
           description: Postal code
         country_code:
           allOf:


### PR DESCRIPTION
Tracking Event Postal Code does not support empty values. Sample valid Tracking Event for the UPS Tracking Number 1Z1E21800376693932

````
{
      "occurred_at": "2020-09-15T20:55:13Z",
      "carrier_occurred_at": "2020-09-15T20:55:13",
      "description": "Destination Scan",
      "city_locality": "Buffalo",
      "state_province": "NY",
      "postal_code": "",
      "country_code": "US",
      "company_name": null,
      "signer": "",
      "event_code": "I",
      "latitude": 42.7898,
      "longitude": -78.8226
 }
````