### PR TITLE
matched address should be nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4079,6 +4079,7 @@ components:
             - $ref: '#/components/schemas/address'
           description: The original address that was sent for validation
         matched_address:
+          nullable: true
           readOnly: true
           allOf:
             - $ref: '#/components/schemas/address'


### PR DESCRIPTION
While the examples have [matched_address as `nullable`](https://github.com/silesky/shipengine-openapi/blob/a85cfdd55ba14dd0c18dd2019f89f8345870ba40/openapi.yaml#L407) (which I have verified through postman), the actual validate schema does not.

So, making this correction.
