### PR TITLE
all fields on response message should be required (though detail_code…

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4128,6 +4128,11 @@ components:
       description: >-
         A response message that displays when additional info is needed for an
         address validation request.
+      required:
+        - code
+        - message
+        - type
+        - detail_code
       additionalProperties: false
       properties:
         code:


### PR DESCRIPTION
_if_ a ResponseMessage exists, all its fields should be on the object (even if one or more is nullable).
