### PR TITLE
Typo on Open API specs for Service Points

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10229,7 +10229,7 @@ components:
           type: number
           example: 2.3591775711639404
           description: >-
-            The latitude of the point. Represented as signed degrees. Required
+            The longitude of the point. Represented as signed degrees. Required
             if lat is provided. http://www.geomidpoint.com/latlon.html
         radius:
           format: int32


### PR DESCRIPTION
**What**
We want to typof in v1/service_points/list. In Field longitude the description is latitude and this is wrong.
**How**
We have changed the word latitude by longitude in parameter longitude.

**Where**
We have changed this files 

- openapi.json
- openapi.yaml

**reference**

This PR solve this BUG https://auctane.atlassian.net/browse/ENGINE-5076