### PR TITLE
Generic carrier disconnection endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1031,7 +1031,7 @@ paths:
         description: Carrier ID
     get:
       summary: Get Carrier By ID
-      description: Retrive carrier info by ID
+      description: Retrieve carrier info by ID
       tags:
         - carriers
       operationId: get_carrier_by_id

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1037,11 +1037,30 @@ paths:
       operationId: get_carrier_by_id
       responses:
         '200':
-          description: The request was a success.
+          description: The request was successful.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/get_carrier_by_id_response_body'
+        '400':
+          $ref: '#/components/responses/400_error_response'
+        '404':
+          $ref: '#/components/responses/404_error_response'
+        '500':
+          $ref: '#/components/responses/500_error_response'
+    delete:
+      summary: Disconnect Carrier By ID
+      description: Disconnect a carrier of specified ID from the account
+      tags:
+        - carriers
+      operationId: disconnect_carrier_by_id
+      responses:
+        '204':
+          description: The request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/empty_response_body'
         '400':
           $ref: '#/components/responses/400_error_response'
         '404':


### PR DESCRIPTION
New generic `/carriers` endpoint for carrier disconnection is being added. In contrary to the current endpoint(s), this one is independent from `carrier_name`.
The issue with the current is that customers sometimes do not know what `carrier_name` value they should pass. Additionally, the carrier name is not used anyhow in the process.

Ticket: https://auctane.atlassian.net/browse/ENGINE-5226